### PR TITLE
Updated readme. Add alpha kwarg to montage classes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,7 @@ Huge thanks to David Bolme for being the originator of Pyvision.
 Many of the ease-of-use and interface ideas from the original Pyvision are carried forward, albeit with new implementations for Pyvision3.
 
 ## Installation
-Install prerequisites that are not pip-installable:
-* python >= 3.4
-* opencv >= 3.0 with bindings for python
+* python >= 3.6
 
 Then install using pip:
 

--- a/examples/image_montage_demo.py
+++ b/examples/image_montage_demo.py
@@ -6,11 +6,17 @@ def main():
     Demonstrates several annotation methods of the Image class
     """
     img1 = pv3.Image(pv3.IMG_DRIVEWAY)
+    img1.annotate_text("sample annotation", (200, 200), color=pv3.RGB_CYAN, bg_color=pv3.RGB_BLACK, font_scale=2)
     img2 = pv3.Image(pv3.IMG_PRIUS)
     img3 = pv3.Image(pv3.IMG_SLEEPYCAT)
     img_list = [img1, img2, img3] * 4
-    imontage = pv3.ImageMontage(img_list, layout=(2, 3), tile_size=(128, 128),
-                                labels="index", keep_aspect=True, highlight_selected=True)
+    imontage = pv3.ImageMontage(img_list,
+                                layout=(1, 3),
+                                tile_size=(480, 360),
+                                labels="index",
+                                keep_aspect=True,
+                                highlight_selected=True,
+                                alpha=0.6)
     imontage.show()  # event loop, blocks until user quits montage
     sel = imontage.get_highlighted()
     sel_str = ",".join([str(x) for x in sel])

--- a/pyvision3/data/project_info.json
+++ b/pyvision3/data/project_info.json
@@ -1,6 +1,6 @@
 {
   "description": "Facilitates computer vision research and prototyping using python and openCV",
-  "version_tuple": [0, 1, 5],
+  "version_tuple": [0, 1, 6],
   "author": "Stephen O'Hara",
   "created":  "2015 December",
   "email": "svohara@gmail.com",

--- a/pyvision3/montage.py
+++ b/pyvision3/montage.py
@@ -23,8 +23,18 @@ class ImageMontage(object):
     than "viewports" in the layout.
     """
 
-    def __init__(self, image_list, layout=(2, 4), tile_size=(64, 48), gutter=2, by_row=True, labels='index',
-                 keep_aspect=True, highlight_selected=False, alpha=0.5):
+    def __init__(
+        self,
+        image_list,
+        layout=(2, 4),
+        tile_size=(64, 48),
+        gutter=2,
+        by_row=True,
+        labels="index",
+        keep_aspect=True,
+        highlight_selected=False,
+        alpha=0.5,
+    ):
         """
         Constructor
 
@@ -71,7 +81,9 @@ class ImageMontage(object):
         self._image_positions = []
         self._select_handler = None
         self._highlighted = highlight_selected
-        self._selected_tiles = []  # which images have been selected (or clicked) by user
+        self._selected_tiles = (
+            []
+        )  # which images have been selected (or clicked) by user
         self.alpha = alpha
 
         # check if we need to allow for scroll-arrow padding
@@ -91,7 +103,7 @@ class ImageMontage(object):
         img_height = self._rows * (tile_size[1] + gutter) + gutter + 2 * self._ypad
         self._size = (img_width, img_height)
 
-        self._cvMontageImage = np.zeros((img_height, img_width, 3), dtype='uint8')
+        self._cvMontageImage = np.zeros((img_height, img_width, 3), dtype="uint8")
 
         self._init_decrement_arrow()  # build the polygon for the decrement arrow
         self._init_increment_arrow()  # build the polygon for the increment arrow
@@ -122,7 +134,9 @@ class ImageMontage(object):
                 for col in range(self._cols):
                     if img_ptr > len(self._images) - 1:
                         break
-                    tile = self._images[img_ptr].as_annotated(as_type="PV", alpha=self.alpha)
+                    tile = self._images[img_ptr].as_annotated(
+                        as_type="PV", alpha=self.alpha
+                    )
                     self._composite(tile, (row, col), img_ptr)
                     img_ptr += 1
         else:
@@ -130,7 +144,9 @@ class ImageMontage(object):
                 for row in range(self._rows):
                     if img_ptr > len(self._images) - 1:
                         break
-                    tile = self._images[img_ptr].as_annotated(as_type="PV", alpha=self.alpha)
+                    tile = self._images[img_ptr].as_annotated(
+                        as_type="PV", alpha=self.alpha
+                    )
                     self._composite(tile, (row, col), img_ptr)
                     img_ptr += 1
 
@@ -226,8 +242,12 @@ class ImageMontage(object):
                     else:
                         self._selected_tiles.append(imgNum)
                     if self._select_handler is not None:
-                        imgLabel = self._labels[imgNum] if isinstance(self._labels, tuple) else str(imgNum)
-                        self._select_handler(img, imgNum, {"imgLabel":imgLabel})
+                        imgLabel = (
+                            self._labels[imgNum]
+                            if isinstance(self._labels, tuple)
+                            else str(imgNum)
+                        )
+                        self._select_handler(img, imgNum, {"imgLabel": imgLabel})
             return 0
 
     def _init_decrement_arrow(self):
@@ -241,19 +261,27 @@ class ImageMontage(object):
             x1 = self._size[0] / 2
             y1 = 2
             halfpad = self._ypad / 2
-            self._decrArrow = np.array([(x1, y1),
-                                        (x1 + halfpad, self._ypad - 2),
-                                        (x1 - halfpad, self._ypad - 2)],
-                                       dtype="int32")
+            self._decrArrow = np.array(
+                [
+                    (x1, y1),
+                    (x1 + halfpad, self._ypad - 2),
+                    (x1 - halfpad, self._ypad - 2),
+                ],
+                dtype="int32",
+            )
         else:
             # decrement leftwards
             x1 = 2
             y1 = self._size[1] / 2
             halfpad = self._xpad / 2
-            self._decrArrow = np.array([(x1, y1),
-                                        (x1 + self._xpad - 3, y1 - halfpad),
-                                        (x1 + self._xpad - 3, y1 + halfpad)],
-                                       dtype="int32")
+            self._decrArrow = np.array(
+                [
+                    (x1, y1),
+                    (x1 + self._xpad - 3, y1 - halfpad),
+                    (x1 + self._xpad - 3, y1 + halfpad),
+                ],
+                dtype="int32",
+            )
 
     def _init_increment_arrow(self):
         """
@@ -266,19 +294,27 @@ class ImageMontage(object):
             x1 = self._size[0] / 2
             y1 = self._size[1] - 3
             halfpad = self._ypad / 2
-            self._incrArrow = np.array([(x1, y1),
-                                        (x1 + halfpad, y1 - self._ypad + 3),
-                                        (x1 - halfpad, y1 - self._ypad + 3)],
-                                       dtype="int32")
+            self._incrArrow = np.array(
+                [
+                    (x1, y1),
+                    (x1 + halfpad, y1 - self._ypad + 3),
+                    (x1 - halfpad, y1 - self._ypad + 3),
+                ],
+                dtype="int32",
+            )
         else:
             # increment rightwards
             x1 = self._size[0] - 2
             y1 = self._size[1] / 2
             halfpad = self._xpad / 2
-            self._incrArrow = np.array([(x1, y1),
-                                        (x1 - self._xpad + 2, y1 - halfpad),
-                                        (x1 - self._xpad + 2, y1 + halfpad)],
-                                       dtype="int32")
+            self._incrArrow = np.array(
+                [
+                    (x1, y1),
+                    (x1 - self._xpad + 2, y1 - halfpad),
+                    (x1 - self._xpad + 2, y1 + halfpad),
+                ],
+                dtype="int32",
+            )
 
     def _decr(self):
         """
@@ -344,9 +380,9 @@ class ImageMontage(object):
 
         # copy pixels of tile onto appropriate location in montage image
         (minx, miny, maxx, maxy) = integer_bounds(roi)
-        cvImg[miny:(maxy+1), minx:(maxx+1), :] = cvTileBGR
+        cvImg[miny : (maxy + 1), minx : (maxx + 1), :] = cvTileBGR
 
-        if self._labels == 'index':
+        if self._labels == "index":
             # draw image number in lower left corner, respective to ROI
             lbltext = "%d" % img_num
         elif isinstance(self._labels, tuple):
@@ -357,26 +393,38 @@ class ImageMontage(object):
         if lbltext is not None:
             ((tw, th), _) = cv2.getTextSize(lbltext, cv2.FONT_HERSHEY_SIMPLEX, 0.5, 1)
             if tw > 0 and th > 0:
-                cv2.rectangle(cvImg,
-                              (pos_x, pos_y + self._tileSize[1] - 1),
-                              (pos_x + tw + 1, pos_y + self._tileSize[1] - (th + 1) - self._gutter),
-                              color=(0, 0, 0),
-                              thickness=cv2.FILLED)
+                cv2.rectangle(
+                    cvImg,
+                    (pos_x, pos_y + self._tileSize[1] - 1),
+                    (
+                        pos_x + tw + 1,
+                        pos_y + self._tileSize[1] - (th + 1) - self._gutter,
+                    ),
+                    color=(0, 0, 0),
+                    thickness=cv2.FILLED,
+                )
                 color = self._txtcolor
-                cv2.putText(cvImg,
-                            lbltext,
-                            (pos_x + 1, pos_y + self._tileSize[1] - self._gutter - 2),  # location
-                            cv2.FONT_HERSHEY_SIMPLEX,  # font face
-                            0.5,  # font scale
-                            color)
+                cv2.putText(
+                    cvImg,
+                    lbltext,
+                    (
+                        pos_x + 1,
+                        pos_y + self._tileSize[1] - self._gutter - 2,
+                    ),  # location
+                    cv2.FONT_HERSHEY_SIMPLEX,  # font face
+                    0.5,  # font scale
+                    color,
+                )
 
         if self._highlighted and (img_num in self._selected_tiles):
             # draw a highlight around this image
-            cv2.rectangle(cvImg,
-                          (int(minx), int(miny)),
-                          (int(maxx), int(maxy)),
-                          (0, 255, 255),
-                          thickness=4)
+            cv2.rectangle(
+                cvImg,
+                (int(minx), int(miny)),
+                (int(maxx), int(maxy)),
+                (0, 255, 255),
+                thickness=4,
+            )
 
 
 class ClickHandler(object):
@@ -397,7 +445,9 @@ class ClickHandler(object):
         Increment or Decrement the set of images shown in the montage
         if appropriate.
         """
-        montage = self.montage_ptr()  # use weak reference to image montage to prevent mem leak
+        montage = (
+            self.montage_ptr()
+        )  # use weak reference to image montage to prevent mem leak
         if montage is None:
             # if the reference was deleted already...
             return
@@ -408,10 +458,12 @@ class ClickHandler(object):
             if rc == -1 and montage._imgPtr > 0:
                 # user clicked in the decrement region
                 montage._decr()
-            elif rc == 1 and montage._imgPtr < (len(montage._images) - (montage._rows * montage._cols)):
+            elif rc == 1 and montage._imgPtr < (
+                len(montage._images) - (montage._rows * montage._cols)
+            ):
                 montage._incr()
             else:
-                pass # do nothing
+                pass  # do nothing
 
             montage.draw()
             cv2.imshow(window, montage._cvMontageImage)
@@ -446,7 +498,9 @@ class VideoMontage(VideoInterface):
         """
         super().__init__(size=None)
         if len(video_dict) < 1:
-            raise ValueError("You must provide at least one video in the video_dict variable.")
+            raise ValueError(
+                "You must provide at least one video in the video_dict variable."
+            )
         self.vids = video_dict
         self.layout = layout
         self.vid_size = tile_size
@@ -488,7 +542,15 @@ class VideoMontage(VideoInterface):
             image_list.append(self.imgs[k])
 
         # create an image montage from the current video frames and advance the frame counter
-        im = ImageMontage(image_list, self.layout, self.vid_size, gutter=2, by_row=True, labels=keys, alpha=self.alpha)
+        im = ImageMontage(
+            image_list,
+            self.layout,
+            self.vid_size,
+            gutter=2,
+            by_row=True,
+            labels=keys,
+            alpha=self.alpha,
+        )
         self.current_frame = im.as_image()
         self.current_frame_num += 1
 

--- a/pyvision3/montage.py
+++ b/pyvision3/montage.py
@@ -24,7 +24,7 @@ class ImageMontage(object):
     """
 
     def __init__(self, image_list, layout=(2, 4), tile_size=(64, 48), gutter=2, by_row=True, labels='index',
-                 keep_aspect=True, highlight_selected=False):
+                 keep_aspect=True, highlight_selected=False, alpha=0.5):
         """
         Constructor
 
@@ -53,6 +53,9 @@ class ImageMontage(object):
             highlight. This will toggle, such that if an image is clicked a second time, the highlighting
             will be removed. The methods get_highlighted and set_highlighted can be used to set/retrieve the
             images in the montage that are highlighted.
+        alpha: float in (0.0, 1.0)
+            Controls the alpha parameter used when rendering each image in the montage, thus controlling
+            the annotation opacity for the constituent images in the montage. Default is 0.5.
         """
         self._tileSize = tile_size
         self._rows = layout[0]
@@ -69,6 +72,7 @@ class ImageMontage(object):
         self._select_handler = None
         self._highlighted = highlight_selected
         self._selected_tiles = []  # which images have been selected (or clicked) by user
+        self.alpha = alpha
 
         # check if we need to allow for scroll-arrow padding
         if self._rows * self._cols < len(image_list):
@@ -118,7 +122,7 @@ class ImageMontage(object):
                 for col in range(self._cols):
                     if img_ptr > len(self._images) - 1:
                         break
-                    tile = self._images[img_ptr].as_annotated(as_type="PV")
+                    tile = self._images[img_ptr].as_annotated(as_type="PV", alpha=self.alpha)
                     self._composite(tile, (row, col), img_ptr)
                     img_ptr += 1
         else:
@@ -126,7 +130,7 @@ class ImageMontage(object):
                 for row in range(self._rows):
                     if img_ptr > len(self._images) - 1:
                         break
-                    tile = self._images[img_ptr].as_annotated(as_type="PV")
+                    tile = self._images[img_ptr].as_annotated(as_type="PV", alpha=self.alpha)
                     self._composite(tile, (row, col), img_ptr)
                     img_ptr += 1
 
@@ -426,7 +430,7 @@ class VideoMontage(VideoInterface):
     a standard video object.
     """
 
-    def __init__(self, video_dict, layout=(2, 4), tile_size=(64, 48)):
+    def __init__(self, video_dict, layout=(2, 4), tile_size=(64, 48), alpha=0.5):
         """
         Parameters
         ----------
@@ -438,6 +442,7 @@ class VideoMontage(VideoInterface):
         tile_size: The window size to display each video in the montage. If the video frame sizes are larger than
             this size, it will be cropped. If you wish to resize, use the size option in the pv.Video class to have
             the output size of the video resized appropriately.
+        alpha: Used to control the annotations opacity in the constituent montages. Default is 0.5.
         """
         super().__init__(size=None)
         if len(video_dict) < 1:
@@ -447,6 +452,7 @@ class VideoMontage(VideoInterface):
         self.vid_size = tile_size
         self.imgs = {}
         self.stopped = []
+        self.alpha = alpha
 
     def reset(self):
         for key in self.vids:
@@ -482,9 +488,8 @@ class VideoMontage(VideoInterface):
             image_list.append(self.imgs[k])
 
         # create an image montage from the current video frames and advance the frame counter
-        im = ImageMontage(image_list, self.layout, self.vid_size, gutter=2, by_row=True, labels=keys)
+        im = ImageMontage(image_list, self.layout, self.vid_size, gutter=2, by_row=True, labels=keys, alpha=self.alpha)
         self.current_frame = im.as_image()
         self.current_frame_num += 1
 
         return self._get_resized()
-

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
         "shapely>=1.3.0",
         "opencv-python"
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.6',
     long_description="""
     A python 3 computer vision library that complements OpenCV 3.x to add many useful features for developers
     and researchers alike. Pyvision provides utilities that help in these core areas: training data preparation,


### PR DESCRIPTION
Updated the readme because pre-installation of opencv is no longer required (hasn't been for a while).

In response to a request by @jfinken, ImageMontage and VideoMontage objects can now control the annotation opacity of their constituent objects by using an `alpha` parameter. This is provided in the constructor. In the ImageMontage, this is used in the `draw` method when drawing each individual image in the montage view, passed onto the `image.as_annotated()` method. Similarly, in the VideoMontage, this is passed onto the ImageMontage created at each time step in the video playback.

Updated the example script `examples/image_montage_demo.py` to show the use of the alpha parameter in the ImageMontage constructor, and that it controls the opacity of the annotation text added to one of the images.